### PR TITLE
feat: use direct YES24 API endpoint for book search

### DIFF
--- a/src/searchUrl.ts
+++ b/src/searchUrl.ts
@@ -11,19 +11,13 @@ const searchBookUrl = async (bookName: string): Promise<searchUrlOutput> => {
 	try {
 		const response = await requestUrl({
 			url:
-				"http://www.yes24.com/Product/Search?domain=BOOK&query=" +
+				"http://www.yes24.com/Product/searchapi/bulletsearch/goods?query=" +
 				bookName,
 		});
-
-		const parser = new DOMParser();
-		const html = parser.parseFromString(response.text, "text/html");
-
-		const bookUrl = html
-			.querySelector(
-				"#yesSchList > li:nth-child(1) > div > div.item_info > div.info_row.info_name > a.gd_name"
-			)
-			.getAttribute("href");
-
+		const data = JSON.parse(response.text);
+		const lstSearchKeywordResult = data?.lstSearchKeywordResult;
+		const bookInfo = lstSearchKeywordResult[0].GOODDS_INDEXES.GOODS_NO;
+		const bookUrl = `/Product/Goods/${bookInfo}`;
 		return { ok: true, url: bookUrl };
 	} catch (err) {
 		console.log(err);


### PR DESCRIPTION
기존 플러그인이 HTML 파싱을 기반으로 YES24 도서 URL을 추출했으나, YES24 검색 페이지 변경으로 더 이상 동작하지 않아 API 기반 방식으로 전환했습니다.

## 🔍 문제 원인
- 기존 구현은 다음 흐름을 따랐습니다:
- 검색어를 포함한 검색 페이지에 요청 → 응답 HTML 파싱 → CSS Selector로 URL 추출
- 그러나 현재 YES24 검색 페이지는 CSR 방식으로 구성되어 있어, 서버 응답 HTML은 빈 템플릿 상태
- 이에 따라 querySelector(...).getAttribute(...) 호출 시 null 에러가 발생하고, 더 이상 URL 추출이 불가능해졌습니다.

## ✅ 변경 사항
- YES24 내부 검색 API인 /Product/searchapi/bulletsearch/goods?query=...를 직접 호출
- 이 API는 검색어 입력 시 사용되는 autocomplete용 endpoint이며, 도서의 GOODS_NO(고유 ID)를 포함함
- 도서 상세 페이지는 https://www.yes24.com/Product/Goods/{GOODS_NO} 형식이므로, 이 ID만 있으면 URL 생성 가능
- HTML 파싱 및 CSS Selector 제거 → JSON 파싱 방식으로 변경

## 기타 
- YES24의 해당 API가 public endpoint라 문제가 없으나, 추후 차단될 경우 대응 방안 필요